### PR TITLE
Call `travis_terminate` inside `if [ ]`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_install:
 
 install:
   - |
-    if [ "$TRAVIS_OS_NAME" == osx ]; then
+    if [ "$TRAVIS_OS_NAME" == 'osx' ]; then
         pip install virtualenv
     fi
   - virtualenv $STARFORGE_VENV
@@ -81,7 +81,11 @@ before_script:
         fi
     done
   - set | grep '^BUILD_WHEEL_METAS='
-  - "[ ${#BUILD_WHEEL_METAS[@]} -gt 0 ] || { echo \"No wheel changes for builder '$WHEEL_BUILDER_TYPE', terminating\"; travis_terminate 0; }"
+  - |
+    if [ ${#BUILD_WHEEL_METAS[@]} -eq 0 ]; then
+        echo "No wheel changes for builder '$WHEEL_BUILDER_TYPE', terminating"
+        travis_terminate 0
+    fi
   - |
     if [ "$WHEEL_BUILDER_TYPE" == 'c-extension' ]; then
         case $TRAVIS_OS_NAME in


### PR DESCRIPTION
Calling it as `[ ] || travis_terminate` hangs osx builders when used in `before_script` (although the same thing works in `before_install`).

Thanks for the idea @nsoranzo!

We can rebase #4 once again and it should finally work.