### PR TITLE
Added recipe for galaxycloudrunner

### DIFF
--- a/wheels/galaxycloudrunner/meta.yml
+++ b/wheels/galaxycloudrunner/meta.yml
@@ -1,0 +1,5 @@
+---
+
+type: wheel
+name: galaxycloudrunner
+version: 0.2.0


### PR DESCRIPTION
Adds support for galaxycloudrunner, which enables cloud bursting through cloudlaunch+pulsar.
xref: https://galaxycloudrunner.readthedocs.io
xref: galaxyproject/galaxy#7053
xref: galaxyproject/galaxy#7006
xref: galaxyproject/galaxy#6993