### PR TITLE
Drop support for Python 3.4

### DIFF
--- a/.ci/wheel-cext-builder-setup.sh
+++ b/.ci/wheel-cext-builder-setup.sh
@@ -8,9 +8,6 @@ case $TRAVIS_OS_NAME in
             2.7)
                 pypt=15
                 ;;
-            3.4)
-                pypt=4
-                ;;
             3.5)
                 pypt=4
                 ;;

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
     # arrays cannot be exported in Bash
   matrix:
     - PY="2.7"
-    - PY="3.4"
     - PY="3.5"
     - PY="3.6"
     - PY="3.7"

--- a/starforge.yml
+++ b/starforge.yml
@@ -16,15 +16,12 @@ imagesets:
         - ci/osx-2.7
     cext-osx-wheel:
         - ci/osx-2.7
-        - ci/osx-3.4
         - ci/osx-3.5
         - ci/osx-3.6
         - ci/osx-3.7
     default-wheel:
         - ci/linux-2.7:x86_64
         - ci/linux-2.7:i686
-        - ci/linux-3.4:x86_64
-        - ci/linux-3.4:i686
         - ci/linux-3.5:x86_64
         - ci/linux-3.5:i686
         - ci/linux-3.6:x86_64
@@ -32,7 +29,6 @@ imagesets:
         - ci/linux-3.7:x86_64
         - ci/linux-3.7:i686
         - ci/osx-2.7
-        - ci/osx-3.4
         - ci/osx-3.5
         - ci/osx-3.6
         - ci/osx-3.7
@@ -82,28 +78,6 @@ images:
         py_abi_tags:
             - cp27-cp27m
             - cp27-cp27mu
-        plat_name: manylinux1_i686
-        force_plat: false
-        use_auditwheel: true
-    ci/linux-3.4:x86_64:
-        image: manylinux1:x86_64
-        pkgtool: yum
-        buildpy: /opt/wheelenv/bin/python
-        pythons:
-            - /opt/python/cp34-cp34m/bin/python
-        py_abi_tags:
-            - cp34-cp34m
-        plat_name: manylinux1_x86_64
-        force_plat: false
-        use_auditwheel: true
-    ci/linux-3.4:i686:
-        image: manylinux1:i686
-        pkgtool: yum
-        buildpy: /opt/wheelenv/bin/python
-        pythons:
-            - /opt/python/cp34-cp34m/bin/python
-        py_abi_tags:
-            - cp34-cp34m
         plat_name: manylinux1_i686
         force_plat: false
         use_auditwheel: true
@@ -181,18 +155,6 @@ images:
             - python  # from $PATH = buildpy
         py_abi_tags:
             - cp27-cp27m
-        buildenv:
-            MACOSX_DEPLOYMENT_TARGET: 10.6
-        plat_name: macosx_10_6_intel
-        use_delocate: true
-    ci/osx-3.4:
-        type: local
-        pkgtool: brew
-        buildpy: ~/venv/bin/python
-        pythons:
-            - python  # from $PATH = buildpy
-        py_abi_tags:
-            - cp34-cp34m
         buildenv:
             MACOSX_DEPLOYMENT_TARGET: 10.6
         plat_name: macosx_10_6_intel


### PR DESCRIPTION
It's reaching End-Of-Life on 2018-03-16: https://devguide.python.org/#branchstatus