### PR TITLE
Update galaxycloudrunner version

### DIFF
--- a/wheels/galaxycloudrunner/meta.yml
+++ b/wheels/galaxycloudrunner/meta.yml
@@ -2,4 +2,4 @@
 
 type: wheel
 name: galaxycloudrunner
-version: 0.2.0
+version: 0.3.0


### PR DESCRIPTION
Is this all that needs to be done so Galaxy will auto-install this version at start given a suitable configuration?

GalaxyCloudRunner is a non-pinned, conditional dependency in Galaxy: https://github.com/galaxyproject/galaxy/blob/release_19.05/lib/galaxy/dependencies/conditional-requirements.txt#L15