### PR TITLE
Add netifaces 0.10.9

### DIFF
--- a/wheels/netifaces/meta.yml
+++ b/wheels/netifaces/meta.yml
@@ -1,0 +1,5 @@
+---
+
+name: netifaces
+version: 0.10.9
+type: wheel


### PR DESCRIPTION
Python 3.7 and 3.8 wheels are missing from PyPI, see https://github.com/al45tair/netifaces/issues/33