### PR TITLE
Build bagit 1.7.0 wheel

### DIFF
--- a/wheels/bagit/meta.yml
+++ b/wheels/bagit/meta.yml
@@ -1,0 +1,5 @@
+---
+
+type: wheel
+name: bagit
+version: 1.7.0


### PR DESCRIPTION
There were wheels built and uploaded to PyPI in LibraryOfCongress/bagit-python#109, but removed in LibraryOfCongress/bagit-python#116. This should not be a problematic build on most systems but [at least one problem has been reported](https://help.galaxyproject.org/t/error-command-errored-out-with-exit-status-1-bagit/3356), so let's try putting wheels on wheels.galaxyproject.org.