### PR TITLE
Deploy from master branch

### DIFF
--- a/.github/workflows/starforge.yaml
+++ b/.github/workflows/starforge.yaml
@@ -54,7 +54,7 @@ jobs:
   deploy:
     name: Deploy Wheels
     needs: build
-    if: github.event.pull_request.merged == true
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@v2


### PR DESCRIPTION
Merges are push events, so the deploy didn't happen in https://github.com/galaxyproject/starforge-recipes/actions/runs/514613722